### PR TITLE
feat: adding options for capitalizing variables and overriding variable scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ AMR = """
 
 logic = converter.convert(AMR)
 print(logic)
-# ∃x(boy(x) ^ ¬∃e(:ARG0(e, x) ^ giggle-01(e)))
+# ∃X(boy(X) ^ ¬∃E(:ARG0(E, X) ^ giggle-01(E)))
 ```
 
 ### Coreference Hoisting
@@ -108,7 +108,7 @@ converter = AmrLogicConverter(
 )
 logic = converter.convert(AMR)
 print(logic)
-# ¬∃b(bad-07(b) ∧ ∃e(∃x(:ARG1(b, e) ∧ person(x) ∧ :named(x, "Mr Krupp") ∧ dry-01(e) ∧ :ARG0(e, x) ∧ :ARG1(e, x))))
+# ¬∃B(bad-07(B) ∧ ∃E(∃X(:ARG1(B, E) ∧ person(X) ∧ :named(X, "Mr Krupp") ∧ dry-01(E) ∧ :ARG0(E, X) ∧ :ARG1(E, X))))
 
 # maximally hoist coferences
 converter = AmrLogicConverter(
@@ -117,12 +117,17 @@ converter = AmrLogicConverter(
 )
 logic = converter.convert(AMR)
 print(logic)
-# ∃x(¬∃b(bad-07(b) ∧ ∃e(:ARG1(b, e) ∧ dry-01(e) ∧ :ARG0(e, x) ∧ :ARG1(e, x))) ∧ person(x) ∧ :named(x, "Mr Krupp"))
+# ∃X(¬∃B(bad-07(B) ∧ ∃E(:ARG1(B, E) ∧ dry-01(E) ∧ :ARG0(E, X) ∧ :ARG1(E, X))) ∧ person(X) ∧ :named(X, "Mr Krupp"))
 ```
 
 ### Using Variables for Instances
 
 If you want to use variables for each AMR instance instead of constants, you can pass the option `use_variables_for_instances=True` when creating the AmrLogicConverter instance. When `existentially_quantify_instances` is set, variable will always be used for instances regardless of this setting.
+
+## Misc Options
+
+- By default variables names are capitalized, but you can change this by setting `capitalize_variables=False`.
+- By default, relations like `:ARG0-of(X, Y)` have their arguments flipped in logic and turned into `:ARG0(Y, X)`. If you don't want this normalization to occur, you can disable this by setting `invert_relations=False`.
 
 ## Contributing
 

--- a/amr_logic_converter/AmrContext.py
+++ b/amr_logic_converter/AmrContext.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+from collections import defaultdict
+from dataclasses import dataclass, field, replace
+from typing import Callable, Optional
+from typing_extensions import Literal
+
+from penman.tree import Node, Tree
+
+from amr_logic_converter.extract_instances_from_amr_tree import (
+    extract_instances_from_amr_tree,
+)
+from amr_logic_converter.find_instance_depths import find_instance_depths
+from amr_logic_converter.find_coreferent_instances import find_coreferent_instances
+from amr_logic_converter.map_instances_lca import map_instances_lca
+from amr_logic_converter.map_instances_to_nodes import map_instances_to_nodes
+
+
+@dataclass
+class OverrideInstanceScopeCallbackMeta:
+    """Metadata passed to the OverrideInstanceScopeCallback wtih info about the node being processed"""
+
+    instance_name: str
+    node: Node
+    depth: int
+    is_coreferent: bool
+    is_default_hoisted: bool
+
+
+OverrideInstanceScopeCallback = Callable[
+    [OverrideInstanceScopeCallbackMeta], Optional[Literal["wide", "default"]]
+]
+
+
+@dataclass
+class AmrContext:
+    """
+    Helper class to keep track of relevant information about the AMR tree being processed.
+    """
+
+    amr_tree: Tree
+    instances: frozenset[str]
+    coreferent_instances: frozenset[str]
+    instance_node_map: dict[str, Node]
+    instance_depths_map: dict[str, int]
+    # a map of the scope (instance name of the node in the tree this variable should be scoped) to a list of instances
+    # `None` as the scope means the instance should be scoped around the entire tree
+    scope_instance_map: dict[str | None, list[str]]
+    non_projective_instances: frozenset[str] = field(default_factory=frozenset)
+
+    @classmethod
+    def from_amr_tree(
+        cls,
+        amr_tree: Tree,
+        override_instance_scope: Optional[OverrideInstanceScopeCallback] = None,
+    ) -> AmrContext:
+        instances = extract_instances_from_amr_tree(amr_tree)
+        coreferent_instances = find_coreferent_instances(amr_tree, instances)
+        instance_node_map = map_instances_to_nodes(amr_tree, instances)
+        instance_depths_map = find_instance_depths(amr_tree, instances)
+        instance_lca_map = map_instances_lca(amr_tree, instances)
+        scope_instance_map = _build_scope_instance_map(
+            instance_lca_map=instance_lca_map,
+            instance_depths_map=instance_depths_map,
+            instance_node_map=instance_node_map,
+            coreferent_instances=coreferent_instances,
+            override_scope_callback=override_instance_scope,
+        )
+        return cls(
+            amr_tree=amr_tree,
+            instances=instances,
+            coreferent_instances=coreferent_instances,
+            instance_node_map=instance_node_map,
+            instance_depths_map=instance_depths_map,
+            scope_instance_map=scope_instance_map,
+        )
+
+    def mark_instance_non_projective(self, instance_name: str) -> AmrContext:
+        """Return a new context with the given instance marked as non-projective."""
+        return replace(
+            self,
+            non_projective_instances=self.non_projective_instances | {instance_name},
+        )
+
+    def get_node_for_instance(self, instance_name: str) -> Node:
+        return self.instance_node_map[instance_name]
+
+    def is_instance_projective(self, instance_name: str) -> bool:
+        return instance_name not in self.non_projective_instances
+
+    def get_instance_depth(self, instance_name: str) -> int:
+        return self.instance_depths_map[instance_name]
+
+    def get_instances_at_node_scope(self, node: Node | None) -> list[str]:
+        # None as the node means the widest possible scope
+        return self.scope_instance_map[node[0] if node else None]
+
+
+def _build_scope_instance_map(
+    instance_lca_map: dict[str, str],
+    instance_depths_map: dict[str, int],
+    instance_node_map: dict[str, Node],
+    coreferent_instances: frozenset[str],
+    override_scope_callback: Optional[OverrideInstanceScopeCallback],
+) -> dict[str | None, list[str]]:
+    """
+    Build a map of the scope (instance name of the node in the tree this variable should be scoped) to a list of instances
+    Takes into account any overrides provided by the override_scope_callback
+    """
+    instance_scope_map = {}
+    for instance, lca in instance_lca_map.items():
+        scope: str | None = lca
+        if override_scope_callback:
+            meta = OverrideInstanceScopeCallbackMeta(
+                instance_name=instance,
+                node=instance_node_map[instance],
+                depth=instance_depths_map[instance],
+                is_coreferent=instance in coreferent_instances,
+                is_default_hoisted=lca != instance,
+            )
+            if override_scope_callback(meta) == "wide":
+                scope = None
+        instance_scope_map[instance] = scope
+
+    scope_instance_map: dict[str | None, list[str]] = defaultdict(list)
+    for instance, scope in instance_scope_map.items():
+        scope_instance_map[scope].append(instance)
+    return scope_instance_map


### PR DESCRIPTION
This PR makes the following changes:
- variables are now capitalized by default. This can be changed by passing `capitalize_variables=False`
- any variable can now be scoped to maximum width by passing an `override_instance_scope` closure which returns "wide". This is not documented in the README since the syntax feels a bit clunky and may change in the future.