### PR TITLE
feat: adding an option to turn :condition into implies

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,9 @@
+import re
+
+
+def fmt_logic(text: str) -> str:
+    """Strip excess whitespace and newlines from a string."""
+    updated_txt = re.sub(r"[\s\n]+", " ", text.strip(), flags=re.MULTILINE)
+    updated_txt = re.sub(r"(\()\s+", r"\1", updated_txt)
+    updated_txt = re.sub(r"\s+(\))", r"\1", updated_txt)
+    return updated_txt


### PR DESCRIPTION
This PR adds an option `use_implies_for_conditions` which will turn AMR `:condition` roles into logical implication.